### PR TITLE
Fix scraping-related typos

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ eventbrite: "19827719242"       # optional (insert the alphanumeric key for Even
 -->
 <p id="who">
   <strong>Who:</strong>
-  The course is aimed at graduate students and other researchers. The web scrapping portion
+  The course is aimed at graduate students and other researchers. The web scraping portion
   of the course does require a basic understanding of HTML and HTML switches.
   <strong>Otherwise, you don't need to have any previous knowledge of the tools that will
     be presented at the workshop.</strong>
@@ -163,7 +163,7 @@ eventbrite: "19827719242"       # optional (insert the alphanumeric key for Even
       <tr> <td>09:00</td>  <td>Version control with Git</td> </tr>
       <tr> <td>10:30</td>  <td>Break</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>Web Scrapping with Python and Beautiful Soup</td> </tr>
+      <tr> <td>13:00</td>  <td>Web Scraping with Python and Beautiful Soup</td> </tr>
       <tr> <td>14:30</td>  <td>Break</td> </tr>
       <tr> <td>16:00</td>  <td>Wrap-up</td> </tr>
       <tr> <td>Dismissal</td>  <td><a href='{{ site.swc_post_survey }}{{ site.github.project_title }}'>Post-workshop Survey</a></td> </tr>
@@ -298,14 +298,14 @@ eventbrite: "19827719242"       # optional (insert the alphanumeric key for Even
     </ul>
   </div> -->
   <div class="col-md-6">
-   <h3 id="syllabus-BeautifulSoup"> Scrapping the Web with Beautiful Soup </h3>
+   <h3 id="syllabus-BeautifulSoup"> Scraping the Web with Beautiful Soup </h3>
    <ul>
      <li>HTML - HyerText Markup Language</li>
      <li>Web Browser tools</li>
      <li>Request/Response Model</li>
      <li>Python libraries for web scraping</li>
-     <li>Scaping with Beautiful Soup</li>
-     <li>Scaping with Pandas</li>
+     <li>Scraping with Beautiful Soup</li>
+     <li>Scraping with Pandas</li>
      <li>Web Scraping Best Practices</li>
    </ul>
   </div>


### PR DESCRIPTION
"scrapping" and "scaping" --> "scraping"
